### PR TITLE
Decomposition statistics in default print

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -66,9 +66,8 @@ print.JD3_X13_RSLTS <- function(x, digits = max(3L, getOption("digits") - 3L), s
     cat("Model: X-13\n")
     print(x$preprocessing, digits = digits, summary_info = FALSE, ...)
     cat("\n")
-    cat(sprintf("Seasonal filter: S3X%s", x$decomposition$final_seasonal))
-    cat("\n")
-    cat(sprintf("Trend filter: %s terms Henderson moving average\n", x$decomposition$final_henderson))
+    cat(sprintf("Seasonal filter: S3X%s; ", x$decomposition$final_seasonal))
+    cat(sprintf("Trend filter: H-%s terms\n", x$decomposition$final_henderson))
     cat(
         sprintf("M-Statistics: q %s (%.3f); q-m2 %s (%.3f)\n",
                 ifelse(x$mstats$q <= 1, "Good", "Bad"),

--- a/R/print.R
+++ b/R/print.R
@@ -61,6 +61,7 @@ print_diagnostics <- function(x, digits = max(3L, getOption("digits") - 3L),
 
 #' @export
 print.JD3_X13_RSLTS <- function(x, digits = max(3L, getOption("digits") - 3L), summary_info = getOption("summary_info"),
+                                thresholds_pval = c(0.001, 0.01, 0.05),
                                 ...) {
     cat("Model: X-13\n")
     print(x$preprocessing, digits = digits, summary_info = FALSE, ...)
@@ -68,6 +69,28 @@ print.JD3_X13_RSLTS <- function(x, digits = max(3L, getOption("digits") - 3L), s
     cat(sprintf("Seasonal filter: S3X%s", x$decomposition$final_seasonal))
     cat("\n")
     cat(sprintf("Trend filter: %s terms Henderson moving average\n", x$decomposition$final_henderson))
+    cat(
+        sprintf("M-Statistics: q %s (%.3f); q-m2 %s (%.3f)\n",
+                ifelse(x$mstats$q <= 1, "Good", "Bad"),
+                x$mstats$q,
+                ifelse(x$mstats$qm2 <= 1, "Good", "Bad"),
+                x$mstats$qm2
+        )
+    )
+    cat(
+        sprintf("QS test on SA: %s (%.3f); ",
+                base::cut(x$diagnostics$seas.qstest.sa$pvalue, breaks = c(0, thresholds_pval, Inf),
+                          labels = c("Severe", "Bad", "Uncertain", "Good")),
+                x$diagnostics$seas.qstest.sa$pvalue
+                )
+    )
+    cat(
+        sprintf("F-test on SA: %s (%.3f)\n",
+                base::cut(mod$diagnostics$seas.ftest.sa$pvalue, breaks = c(0, thresholds_pval, Inf),
+                          labels = c("Severe", "Bad", "Uncertain", "Good")),
+                mod$diagnostics$seas.ftest.sa$pvalue
+        )
+    )
     if (summary_info) {
         cat("\nFor a more detailed output, use the 'summary()' function.\n")
     }

--- a/R/print.R
+++ b/R/print.R
@@ -61,7 +61,7 @@ print_diagnostics <- function(x, digits = max(3L, getOption("digits") - 3L),
 
 #' @export
 print.JD3_X13_RSLTS <- function(x, digits = max(3L, getOption("digits") - 3L), summary_info = getOption("summary_info"),
-                                thresholds_pval = c(0.001, 0.01, 0.05),
+                                thresholds_pval = getOption("thresholds_pval"),
                                 ...) {
     cat("Model: X-13\n")
     print(x$preprocessing, digits = digits, summary_info = FALSE, ...)
@@ -78,16 +78,16 @@ print.JD3_X13_RSLTS <- function(x, digits = max(3L, getOption("digits") - 3L), s
     )
     cat(
         sprintf("QS test on SA: %s (%.3f); ",
-                base::cut(x$diagnostics$seas.qstest.sa$pvalue, breaks = c(0, thresholds_pval, Inf),
-                          labels = c("Severe", "Bad", "Uncertain", "Good")),
+                base::cut(x$diagnostics$seas.qstest.sa$pvalue, breaks = c(0, thresholds_pval),
+                          labels = names(thresholds_pval)),
                 x$diagnostics$seas.qstest.sa$pvalue
                 )
     )
     cat(
         sprintf("F-test on SA: %s (%.3f)\n",
-                base::cut(mod$diagnostics$seas.ftest.sa$pvalue, breaks = c(0, thresholds_pval, Inf),
-                          labels = c("Severe", "Bad", "Uncertain", "Good")),
-                mod$diagnostics$seas.ftest.sa$pvalue
+                base::cut(x$diagnostics$seas.ftest.sa$pvalue, breaks = c(0, thresholds_pval),
+                          labels = names(thresholds_pval)),
+                x$diagnostics$seas.ftest.sa$pvalue
         )
     )
     if (summary_info) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,4 +17,7 @@
     if (is.null(getOption("summary_info"))) {
         options(summary_info = TRUE)
     }
+    if (is.null(getOption("thresholds_pval"))) {
+        options(thresholds_pval = c("Severe" = 0.001, "Bad" = 0.01, "Uncertain" = 0.05, "Good" = Inf))
+    }
 }


### PR DESCRIPTION
I propose to add some statistics on the decomposition (max 2 lines) in the default print
``` r
rjd3x13::x13_fast(rjd3toolkit::ABS$X0.2.09.10.M)
#> Model: X-13
#> Log-transformation: yes 
#> SARIMA model: (2,1,1) (0,1,1)
#> 
#> SARIMA coefficients:
#>    phi(1)    phi(2)  theta(1) btheta(1) 
#>    0.3474    0.2173   -0.6994   -0.4804 
#> 
#> Regression model:
#>              td          easter TC (2000-06-01) AO (2000-07-01) 
#>        0.002323        0.052011        0.159034       -0.290077 
#> 
#> Seasonal filter: S3X3; Trend filter: H-23 terms
#> M-Statistics: q Good (0.465); q-m2 Good (0.513)
#> QS test on SA: Severe (0.000); F-test on SA: Good (0.997)
#> 
#> For a more detailed output, use the 'summary()' function.
```
By default the threshold are the one of JDemetra+ but can be set with the option `thresholds_pval`